### PR TITLE
Fix IRQ related issues

### DIFF
--- a/src/interrupts/idt.c
+++ b/src/interrupts/idt.c
@@ -21,7 +21,7 @@ typedef struct {
 
 typedef struct {
 	uint16_t limit;
-	uint32_t base;
+	uintptr_t base;
 } __attribute__((packed)) idtr_t;
 
 __attribute__((aligned(0x10))) static idt_entry_t idt[IDT_MAX_DESCRIPTORS];

--- a/src/interrupts/idt.c
+++ b/src/interrupts/idt.c
@@ -42,15 +42,15 @@ void idt_set_descriptor(uint8_t vector, void* isr, uint8_t flags) {
 }
 
 void exception_handler(void) { stop(); }
+void irq_handler(void) { }
 
 void init_idt() {
 	idtr.base = (uintptr_t)&idt[0];
 	idtr.limit = (uint16_t)sizeof(idt_entry_t) * IDT_MAX_DESCRIPTORS - 1;
 
-	for (uint8_t vector = 0; vector < 32; vector++) {
+	for (uint8_t vector = 0; vector < 48; vector++) {
 		idt_set_descriptor(vector, isr_stub_table[vector], 0x8e);  // 0x8e = interrupt gate
 	}
 
-	__asm__ __volatile__("lidt %0" : : "m"(idtr));
-	__asm__ __volatile__("sti");
+	__asm__ __volatile__("lidt %0" : : "m"(idtr) : "memory");
 }

--- a/src/interrupts/isr.asm
+++ b/src/interrupts/isr.asm
@@ -1,5 +1,5 @@
 %macro irq_stub 1
-isr_stub_%+%1:
+irq_stub_%+%1:
     call irq_handler
     iretq
 %endmacro
@@ -17,6 +17,7 @@ isr_stub_%+%1:
 %endmacro
 
 extern exception_handler
+extern irq_handler
 
 isr_no_err_stub 0
 isr_no_err_stub 1
@@ -72,7 +73,13 @@ irq_stub 47
 global isr_stub_table
 isr_stub_table:
 %assign i 0 
-%rep    48
+%rep    32
     dq isr_stub_%+i
+%assign i i+1 
+%endrep
+
+%assign i 32 
+%rep    16
+    dq irq_stub_%+i
 %assign i i+1 
 %endrep

--- a/src/interrupts/isr.asm
+++ b/src/interrupts/isr.asm
@@ -7,6 +7,7 @@ irq_stub_%+%1:
 %macro isr_err_stub 1
 isr_stub_%+%1:
     call exception_handler
+    add rsp, 8 ; Remove error code from stack
     iretq
 %endmacro
 

--- a/src/interrupts/isr.asm
+++ b/src/interrupts/isr.asm
@@ -1,3 +1,9 @@
+%macro irq_stub 1
+isr_stub_%+%1:
+    call irq_handler
+    iretq
+%endmacro
+
 %macro isr_err_stub 1
 isr_stub_%+%1:
     call exception_handler
@@ -45,10 +51,28 @@ isr_no_err_stub 29
 isr_err_stub    30
 isr_no_err_stub 31
 
+; IRQ0 to IRQ15
+irq_stub 32
+irq_stub 33
+irq_stub 34
+irq_stub 35
+irq_stub 36
+irq_stub 37
+irq_stub 38
+irq_stub 39
+irq_stub 40
+irq_stub 41
+irq_stub 42
+irq_stub 43
+irq_stub 44
+irq_stub 45
+irq_stub 46
+irq_stub 47
+
 global isr_stub_table
 isr_stub_table:
 %assign i 0 
-%rep    32 
+%rep    48
     dq isr_stub_%+i
 %assign i i+1 
 %endrep

--- a/src/interrupts/pic.c
+++ b/src/interrupts/pic.c
@@ -48,7 +48,9 @@ static void PIC_remap(int master_off, int slave_off) {
 }
 
 void init_PIC(void) {
-	__asm__ __volatile__("cli");  // disable interrupts
 	PIC_remap(0x20, 0x28);
-	__asm__ __volatile__("sti");  // enable interrupts
+}
+
+void enable_interrupts(void) {
+	__asm__ __volatile__("sti" ::: "memory");  // enable interrupts
 }

--- a/src/interrupts/pic.h
+++ b/src/interrupts/pic.h
@@ -2,4 +2,5 @@
 #define PIC_H
 
 void init_PIC(void);
+void enable_interrupts(void);
 #endif // PIC_H

--- a/src/kernel/kmain.c
+++ b/src/kernel/kmain.c
@@ -28,6 +28,7 @@ void kmain(void) {
 	set_font_scale(2);
 	init_idt();
     init_PIC();
+    enable_interrupts();
 
 	stop();
 }


### PR DESCRIPTION
- Fix page fault caused by the `base` in `idtr_t` being the wrong type. Should be `uintptr_t` (or `uint64_t`) instead of `uint32_t`
- Enable interrupts only after remapping the PICs and setting the IDT
- Add stub handlers for the IRQs

Todo: need to properly save and restore the registers and other CPU state in the IRQ and ISR handlers